### PR TITLE
fix null l1Transaction

### DIFF
--- a/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
@@ -30,8 +30,8 @@ export const handleEventsSequencerBatchAppended: EventHandlerSet<
   SequencerBatchAppendedParsedEvent
 > = {
   getExtraData: async (event, l1RpcProvider) => {
-    const l1Transaction = await event.getTransaction()
-    const eventBlock = await event.getBlock()
+    const eventBlock = await l1RpcProvider.getBlockWithTransactions(event.blockNumber)
+    const l1Transaction = eventBlock.transactions.find(i=>i.hash == event.transactionHash)
 
     // TODO: We need to update our events so that we actually have enough information to parse this
     // batch without having to pull out this extra event. For the meantime, we need to find this

--- a/packages/data-transport-layer/src/services/l1-ingestion/handlers/state-batch-appended.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/handlers/state-batch-appended.ts
@@ -18,9 +18,9 @@ export const handleEventsStateBatchAppended: EventHandlerSet<
   StateBatchAppendedExtraData,
   StateBatchAppendedParsedEvent
 > = {
-  getExtraData: async (event) => {
-    const eventBlock = await event.getBlock()
-    const l1Transaction = await event.getTransaction()
+  getExtraData: async (event, l1RpcProvider) => {
+    const eventBlock = await l1RpcProvider.getBlockWithTransactions(event.blockNumber)
+    const l1Transaction = eventBlock.transactions.find(i=>i.hash == event.transactionHash)
 
     return {
       timestamp: eventBlock.timestamp,


### PR DESCRIPTION
eth-docker by default will prune historical txHash=>tx relation, so `event.getTransaction()` will return null

Change to getBlockWithTransactions and find the tx instead, this will fix https://github.com/MetisProtocol/metis-replica-node/issues/34 and https://github.com/MetisProtocol/metis-replica-node/issues/36