### PR TITLE
fix: fix fraud proof audit issues

### DIFF
--- a/go/op-challenger/abi/override/DisputeGameFactory.json
+++ b/go/op-challenger/abi/override/DisputeGameFactory.json
@@ -13,17 +13,23 @@
   {
     "inputs": [
       {
+        "internalType": "bytes32",
+        "name": "uuid",
+        "type": "bytes32"
+      }
+    ],
+    "name": "AlreadyDisputed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "Hash",
         "name": "uuid",
         "type": "bytes32"
       }
     ],
     "name": "GameAlreadyExists",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "IncorrectBondAmount",
     "type": "error"
   },
   {
@@ -154,19 +160,101 @@
     "inputs": [
       {
         "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
         "internalType": "address",
-        "name": "previousOwner",
+        "name": "account",
         "type": "address"
       },
       {
         "indexed": true,
         "internalType": "address",
-        "name": "newOwner",
+        "name": "sender",
         "type": "address"
       }
     ],
-    "name": "OwnershipTransferred",
+    "name": "RoleGranted",
     "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "GAME_CREATOR_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   },
   {
     "inputs": [],
@@ -445,6 +533,67 @@
   {
     "inputs": [
       {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "GameType",
         "name": "",
         "type": "uint32"
@@ -475,21 +624,37 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "owner",
-    "outputs": [
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
       {
         "internalType": "address",
-        "name": "",
+        "name": "account",
         "type": "address"
       }
     ],
-    "stateMutability": "view",
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "renounceOwnership",
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -533,14 +698,20 @@
   {
     "inputs": [
       {
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
       }
     ],
-    "name": "transferOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/go/op-challenger/abi/override/StateCommitmentChain.json
+++ b/go/op-challenger/abi/override/StateCommitmentChain.json
@@ -21,6 +21,16 @@
     "type": "constructor"
   },
   {
+    "inputs": [],
+    "name": "ClaimAlreadyResolved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnregisteredGame",
+    "type": "error"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {
@@ -103,6 +113,19 @@
   },
   {
     "inputs": [],
+    "name": "DISPUTE_GAME_FACTORY_NAME",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "FRAUD_PROOF_WINDOW",
     "outputs": [
       {
@@ -138,6 +161,16 @@
         "internalType": "uint256",
         "name": "_shouldStartAtElement",
         "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_lastBatchBlockHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_lastBatchBlockNumber",
+        "type": "uint256"
       }
     ],
     "name": "appendStateBatch",
@@ -164,13 +197,66 @@
       },
       {
         "internalType": "string",
-        "name": "proposer",
+        "name": "_proposer",
         "type": "string"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_lastBatchBlockHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_lastBatchBlockNumber",
+        "type": "uint256"
       }
     ],
     "name": "appendStateBatchByChainId",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "batchLastL2BlockNumbers",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "batchTimes",
+    "outputs": [
+      {
+        "internalType": "bytes16",
+        "name": "",
+        "type": "bytes16"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -269,6 +355,73 @@
     "name": "deleteStateBatchByChainId",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "disputedBatches",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      }
+    ],
+    "name": "findEarliestDisputableBatch",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "batchHeaderHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lastL2BlockNumber",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IMVMStateCommitmentChain.BatchInfo",
+        "name": "_lastFinalized",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "batchHeaderHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lastL2BlockNumber",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IMVMStateCommitmentChain.BatchInfo",
+        "name": "_earliestDisputable",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -465,6 +618,25 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "stateHeaderHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isDisputedBatch",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "libAddressManager",
     "outputs": [
@@ -494,6 +666,19 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "stateHeaderHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "saveDisputedBatch",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/go/op-challenger/game/fault/contracts/gamefactory.go
+++ b/go/op-challenger/game/fault/contracts/gamefactory.go
@@ -21,6 +21,10 @@ import (
 )
 
 const (
+	gameCreatorRole = "0x9b2f12f1d3f61516c0ebe58c227a91273c07455ba15edc01d82cb364c3d54d02"
+)
+
+const (
 	methodGameCount         = "gameCount"
 	methodGameAtIndex       = "gameAtIndex"
 	methodGameImpls         = "gameImpls"
@@ -28,7 +32,7 @@ const (
 	methodCreateGame        = "create"
 	methodCreateDispute     = "dispute"
 	methodGames             = "games"
-	methodOwner             = "owner"
+	methodHasRole           = "hasRole"
 	methodGameRequests      = "disputeGameCreationRequests"
 	methodMetisTokenAddress = "METIS"
 
@@ -207,7 +211,7 @@ func (f *DisputeGameFactoryContract) GetAllGames(ctx context.Context, blockHash 
 }
 
 func (f *DisputeGameFactoryContract) CreateTx(ctx context.Context, traceType uint32, outputRoot common.Hash, l2BlockNum uint64) (txmgr.TxCandidate, error) {
-	if err := f.checkOwner(ctx); err != nil {
+	if err := f.checkRole(ctx); err != nil {
 		return txmgr.TxCandidate{}, err
 	}
 
@@ -301,14 +305,13 @@ func (f *DisputeGameFactoryContract) Addr() common.Address {
 	return f.contract.Addr()
 }
 
-func (f *DisputeGameFactoryContract) checkOwner(ctx context.Context) error {
-	res, err := f.multiCaller.SingleCall(ctx, rpcblock.Latest, f.contract.Call(methodOwner))
+func (f *DisputeGameFactoryContract) checkRole(ctx context.Context) error {
+	res, err := f.multiCaller.SingleCall(ctx, rpcblock.Latest, f.contract.Call(methodHasRole, common.HexToHash(gameCreatorRole), f.from))
 	if err != nil {
-		return fmt.Errorf("failed to fetch owner: %w", err)
+		return fmt.Errorf("failed to fetch role: %w", err)
 	}
-	owner := res.GetAddress(0)
-	if owner != f.from {
-		return fmt.Errorf("owner mismatch (only owner can create game): %v != %v", owner.Hex(), f.from.Hex())
+	if !res.GetBool(0) {
+		return fmt.Errorf("address %s is not permitted to create game", f.from.Hex())
 	}
 
 	return nil

--- a/packages/contracts/contracts/L1/cannon/MIPS2.sol
+++ b/packages/contracts/contracts/L1/cannon/MIPS2.sol
@@ -441,7 +441,7 @@ contract MIPS2 is ISemver {
                 // ignored
             } else if (syscall_no == sys.SYS_TIMERDELETE) {
                 // ignored
-            } else if (syscall_no == sys.SYS_CLOCKGETTIME) {
+            } else if (syscall_no == sys.SYS_CLOCK_GETTIME) {
                 // ignored
             } else if (syscall_no == sys.SYS_MUNMAP) {
                 // ignored

--- a/packages/contracts/contracts/L1/cannon/libraries/MIPSSyscalls.sol
+++ b/packages/contracts/contracts/L1/cannon/libraries/MIPSSyscalls.sol
@@ -44,7 +44,6 @@ library MIPSSyscalls {
     // unused syscalls
     uint32 internal constant SYS_CLOCK_GETTIME = 4263;
     uint32 internal constant SYS_GET_AFFINITY = 4240;
-    uint32 internal constant SYS_GETAFFINITY = 4240;
     uint32 internal constant SYS_MADVISE = 4218;
     uint32 internal constant SYS_RTSIGPROCMASK = 4195;
     uint32 internal constant SYS_SIGALTSTACK = 4206;
@@ -74,7 +73,6 @@ library MIPSSyscalls {
     uint32 internal constant SYS_TIMERCREATE = 4257;
     uint32 internal constant SYS_TIMERSETTIME = 4258;
     uint32 internal constant SYS_TIMERDELETE = 4261;
-    uint32 internal constant SYS_CLOCKGETTIME = 4263;
     uint32 internal constant SYS_MUNMAP = 4091;
 
     uint32 internal constant FD_STDIN = 0;
@@ -305,20 +303,22 @@ library MIPSSyscalls {
 
                 // Construct pre-image key from memory
                 // We use assembly for more precise ops, and no var count limit
+                // add a local a2 to avoid modification to _a2 not reflected in the assembly code
+                uint32 a2 = _a2;
                 assembly {
                     let alignment := and(_a1, 3) // the read might not start at an aligned address
                     let space := sub(4, alignment) // remaining space in memory word
-                    if lt(space, _a2) {_a2 := space} // if less space than data, shorten data
-                    key := shl(mul(_a2, 8), key) // shift key, make space for new info
-                    let mask := sub(shl(mul(_a2, 8), 1), 1) // mask for extracting value from memory
-                    mem := and(shr(mul(sub(space, _a2), 8), mem), mask) // align value to right, mask it
+                    if lt(space, a2) {a2 := space} // if less space than data, shorten data
+                    key := shl(mul(a2, 8), key) // shift key, make space for new info
+                    let mask := sub(shl(mul(a2, 8), 1), 1) // mask for extracting value from memory
+                    mem := and(shr(mul(sub(space, a2), 8), mem), mask) // align value to right, mask it
                     key := or(key, mem) // insert into key
                 }
 
                 // Write pre-image key to oracle
                 newPreimageKey_ = key;
                 newPreimageOffset_ = 0; // reset offset, to read new pre-image data from the start
-                v0_ = _a2;
+                v0_ = a2;
             } else {
                 v0_ = 0xFFffFFff;
                 v1_ = EBADF;

--- a/packages/contracts/contracts/L1/dispute/DisputeGameFactory.sol
+++ b/packages/contracts/contracts/L1/dispute/DisputeGameFactory.sol
@@ -64,6 +64,7 @@ contract DisputeGameFactory is AccessControlUpgradeable, IDisputeGameFactory, IS
     function initialize(address _owner) public initializer {
         __AccessControl_init();
         _grantRole(DEFAULT_ADMIN_ROLE, _owner);
+        _grantRole(GAME_CREATOR_ROLE, _owner);
     }
 
     /// @inheritdoc IDisputeGameFactory
@@ -157,15 +158,16 @@ contract DisputeGameFactory is AccessControlUpgradeable, IDisputeGameFactory, IS
         // Clone the implementation contract and initialize it with the given parameters.
         //
         // CWIA Calldata Layout:
-        // ┌──────────────┬────────────────────────────────────┐
-        // │    Bytes     │            Description             │
-        // ├──────────────┼────────────────────────────────────┤
-        // │ [0, 20)      │ Game creator address               │
-        // │ [20, 52)     │ Root claim                         │
-        // │ [52, 84)     │ Parent block hash at creation time │
-        // │ [84, 84 + n) │ Extra data (opaque)                │
-        // └──────────────┴────────────────────────────────────┘
-        proxy_ = IDisputeGame(address(impl).clone(abi.encodePacked(msg.sender, _rootClaim, info.l1Head, _extraData)));
+        // ┌────────────────┬────────────────────────────────────┐
+        // │    Bytes       │            Description             │
+        // ├────────────────┼────────────────────────────────────┤
+        // │ [0, 20)        │ Game creator address               │
+        // │ [20, 52)       │ Root claim                         │
+        // │ [52, 84)       │ Parent block hash at creation time │
+        // │ [84, 104)      │ Dispute creator                    │
+        // │ [104, 104 + n) │ Extra data (opaque)                │
+        // └────────────────┴────────────────────────────────────┘
+        proxy_ = IDisputeGame(address(impl).clone(abi.encodePacked(msg.sender, _rootClaim, info.l1Head, info.sender, _extraData)));
 
         // Only transfer bond if it's not zero
         if (info.bond > 0) {

--- a/packages/contracts/contracts/L1/dispute/DisputeGameFactory.sol
+++ b/packages/contracts/contracts/L1/dispute/DisputeGameFactory.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.15;
 import {ISemver} from "../../universal/ISemver.sol";
 import {IDisputeGame} from "./interfaces/IDisputeGame.sol";
 import {IDisputeGameFactory} from "./interfaces/IDisputeGameFactory.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import {LibClone} from "solady/src/utils/LibClone.sol";
 import "contracts/L1/dispute/lib/Types.sol";
 import "contracts/L1/dispute/lib/Errors.sol";
@@ -15,9 +15,11 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 ///         mapping and an append only array. The timestamp of the creation time of the dispute game is packed tightly
 ///         into the storage slot with the address of the dispute game to make offchain discoverability of playable
 ///         dispute games easier.
-contract DisputeGameFactory is OwnableUpgradeable, IDisputeGameFactory, ISemver {
+contract DisputeGameFactory is AccessControlUpgradeable, IDisputeGameFactory, ISemver {
     /// @dev Allows for the creation of clone proxies with immutable arguments.
     using LibClone for address;
+
+    bytes32 public constant GAME_CREATOR_ROLE = keccak256("GAME_CREATOR");
 
     struct DisputeInfo {
         GameType gameType;
@@ -52,7 +54,7 @@ contract DisputeGameFactory is OwnableUpgradeable, IDisputeGameFactory, ISemver 
 
     /// @notice Constructs a new DisputeGameFactory contract.
     /// @param _metis The Metis ERC20 token contract
-    constructor(IERC20 _metis) OwnableUpgradeable() {
+    constructor(IERC20 _metis) AccessControlUpgradeable() {
         METIS = _metis;
         initialize(address(0));
     }
@@ -60,8 +62,8 @@ contract DisputeGameFactory is OwnableUpgradeable, IDisputeGameFactory, ISemver 
     /// @notice Initializes the contract.
     /// @param _owner The owner of the contract.
     function initialize(address _owner) public initializer {
-        __Ownable_init();
-        _transferOwnership(_owner);
+        __AccessControl_init();
+        _grantRole(DEFAULT_ADMIN_ROLE, _owner);
     }
 
     /// @inheritdoc IDisputeGameFactory
@@ -121,7 +123,11 @@ contract DisputeGameFactory is OwnableUpgradeable, IDisputeGameFactory, ISemver 
             bond: initBond,
             l1Head: parentHash
         });
-        disputeGameCreationRequests[keccak256(abi.encodePacked(_gameType, _extraData))] = info;
+
+        bytes32 uuid = keccak256(abi.encodePacked(_gameType, _extraData));
+        if (disputeGameCreationRequests[uuid].l1Head != bytes32(0)) revert AlreadyDisputed(uuid);
+
+        disputeGameCreationRequests[uuid] = info;
 
         emit DisputeGameRequested(msg.sender, _gameType, initBond, _extraData);
     }
@@ -133,7 +139,7 @@ contract DisputeGameFactory is OwnableUpgradeable, IDisputeGameFactory, ISemver 
         bytes calldata _extraData
     )
     external
-    onlyOwner
+    onlyRole(GAME_CREATOR_ROLE)
     returns (IDisputeGame proxy_)
     {
         // Grab the implementation contract for the given `GameType`.
@@ -147,9 +153,6 @@ contract DisputeGameFactory is OwnableUpgradeable, IDisputeGameFactory, ISemver 
         DisputeInfo memory info = disputeGameCreationRequests[requestUuid];
 
         if (info.l1Head == bytes32(0)) revert NoDisputeGameRequests();
-
-        // If the required initialization bond is not met, revert.
-        if (info.bond != initBonds[_gameType]) revert IncorrectBondAmount();
 
         // Clone the implementation contract and initialize it with the given parameters.
         //
@@ -254,13 +257,13 @@ contract DisputeGameFactory is OwnableUpgradeable, IDisputeGameFactory, ISemver 
     }
 
     /// @inheritdoc IDisputeGameFactory
-    function setImplementation(GameType _gameType, IDisputeGame _impl) external onlyOwner {
+    function setImplementation(GameType _gameType, IDisputeGame _impl) external onlyRole(DEFAULT_ADMIN_ROLE) {
         gameImpls[_gameType] = _impl;
         emit ImplementationSet(address(_impl), _gameType);
     }
 
     /// @inheritdoc IDisputeGameFactory
-    function setInitBond(GameType _gameType, uint256 _initBond) external onlyOwner {
+    function setInitBond(GameType _gameType, uint256 _initBond) external onlyRole(DEFAULT_ADMIN_ROLE) {
         initBonds[_gameType] = _initBond;
         emit InitBondUpdated(_gameType, _initBond);
     }

--- a/packages/contracts/contracts/L1/dispute/FaultDisputeGame.sol
+++ b/packages/contracts/contracts/L1/dispute/FaultDisputeGame.sol
@@ -229,15 +229,16 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
         // in the factory, but are not used by the game, which would allow for multiple dispute games for the same
         // output proposal to be created.
         //
-        // Expected length: 0x7A
+        // Expected length: 0x8E
         // - 0x04 selector
-        // - 0x14 creator address
+        // - 0x14 game creator address
         // - 0x20 root claim
         // - 0x20 l1 head
+        // - 0x14 dispute creator address
         // - 0x20 extraData
         // - 0x02 CWIA bytes
         assembly {
-            if iszero(eq(calldatasize(), 0x7A)) {
+            if iszero(eq(calldatasize(), 0x8E)) {
             // Store the selector for `BadExtraData()` & revert
                 mstore(0x00, 0x9824bdab)
                 revert(0x1C, 0x04)
@@ -559,7 +560,7 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
 
     /// @inheritdoc IFaultDisputeGame
     function l2BlockNumber() public pure returns (uint256 l2BlockNumber_) {
-        l2BlockNumber_ = _getArgUint256(0x54);
+        l2BlockNumber_ = _getArgUint256(0x68);
     }
 
     /// @inheritdoc IFaultDisputeGame
@@ -751,14 +752,16 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
             // Distribute the bond to the appropriate party.
             if (_claimIndex == 0 && l2BlockNumberChallenged) {
                 // Special case: If the root claim has been challenged with the `challengeRootL2Block` function,
-                // the bond is always paid out to the issuer of that challenge.
-                address challenger = l2BlockNumberChallenger;
-                _distributeBond(challenger, subgameRootClaim);
-                subgameRootClaim.counteredBy = challenger;
+                // the bond is always paid out to the dispute creator.
+                _distributeBond(disputeCreator(), subgameRootClaim);
+                subgameRootClaim.counteredBy = l2BlockNumberChallenger;
             } else {
                 // If the parent was not successfully countered, pay out the parent's bond to the claimant.
-                // If the parent was successfully countered, pay out the parent's bond to the challenger.
-                _distributeBond(countered == address(0) ? subgameRootClaim.claimant : countered, subgameRootClaim);
+                // If the parent was successfully countered:
+                // 1. claimIndex is not 0: pay out the parent's bond to the challenger.
+                // 2. claimIndex is 0: pay out the parent's bond to the dispute creator
+                address challenger = _claimIndex == 0 ? disputeCreator() : countered;
+                _distributeBond(countered == address(0) ? subgameRootClaim.claimant : challenger, subgameRootClaim);
 
                 // Once a subgame is resolved, we percolate the result up the DAG so subsequent calls to
                 // resolveClaim will not need to traverse this subgame.
@@ -788,10 +791,15 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
     }
 
     /// @inheritdoc IDisputeGame
+    function disputeCreator() public pure returns (address creator_) {
+        creator_ = _getArgAddress(0x54);
+    }
+
+    /// @inheritdoc IDisputeGame
     function extraData() public pure returns (bytes memory extraData_) {
         // The extra data starts at the second word within the cwia calldata and
         // is 32 bytes long.
-        extraData_ = _getArgBytes(0x54, 0x20);
+        extraData_ = _getArgBytes(0x68, 0x20);
     }
 
     /// @inheritdoc IDisputeGame

--- a/packages/contracts/contracts/L1/dispute/FaultDisputeGame.sol
+++ b/packages/contracts/contracts/L1/dispute/FaultDisputeGame.sol
@@ -25,10 +25,13 @@ import {Types} from "../../libraries/Types.sol";
 
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /// @title FaultDisputeGame
 /// @notice An implementation of the `IFaultDisputeGame` interface.
 contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
+    using SafeERC20 for IERC20;
+
     ////////////////////////////////////////////////////////////////
     //                         State Vars                         //
     ////////////////////////////////////////////////////////////////
@@ -207,18 +210,18 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
 
         // Grab the latest anchor root.
         IMVMStateCommitmentChain stateCommitmentChain = IMVMStateCommitmentChain(ADDRESS_MANAGER.getAddress(SCC_NAME));
-        (bytes32 scRoot, uint256 rootBlockNumber) = stateCommitmentChain.findEarliestDisputableBatch(L2_CHAIN_ID);
+        (IMVMStateCommitmentChain.BatchInfo memory lastFinalized, IMVMStateCommitmentChain.BatchInfo memory earliestDisputable) = stateCommitmentChain.findEarliestDisputableBatch(L2_CHAIN_ID);
 
-        Hash root = Hash.wrap(scRoot);
+        Hash root = Hash.wrap(earliestDisputable.batchHeaderHash);
 
         // Should only happen if this is a new game type that hasn't been set up yet.
         if (root.raw() == bytes32(0)) revert AnchorRootNotFound();
 
         // we do not allow to dispute an already disputed batch
-        if (stateCommitmentChain.isDisputedBatch(scRoot)) revert ClaimAlreadyResolved();
+        if (stateCommitmentChain.isDisputedBatch(earliestDisputable.batchHeaderHash)) revert ClaimAlreadyResolved();
 
         // Set the starting output root.
-        startingOutputRoot = OutputRoot({l2BlockNumber: rootBlockNumber, root: root});
+        startingOutputRoot = OutputRoot({l2BlockNumber: lastFinalized.lastL2BlockNumber, root: Hash.wrap(lastFinalized.batchHeaderHash)});
 
         // Revert if the calldata size is not the expected length.
         //
@@ -243,7 +246,7 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
 
         // Do not allow the game to be initialized if the root claim corresponds to a block at or before the
         // configured starting block number.
-        if (l2BlockNumber() <= rootBlockNumber) revert UnexpectedRootClaim(rootClaim());
+        if (l2BlockNumber() < earliestDisputable.lastL2BlockNumber) revert UnexpectedRootClaim(rootClaim());
 
         IDelayedWMetis wmet = WMETIS;
         IERC20 met = wmet.metisToken();
@@ -266,7 +269,7 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
 
         // Convert the initial bond from METIS to WMETIS
         uint256 initialBond = met.balanceOf(address(this));
-        met.approve(address(wmet), initialBond);
+        met.safeApprove(address(wmet), initialBond);
         wmet.deposit(initialBond);
 
         // Set the game's starting timestamp
@@ -485,10 +488,10 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
         // Transfer the bond from the sender to this contract
         if (requiredBond > 0) {
             IERC20 met = IERC20(wmet.metisToken());
-            met.transferFrom(msg.sender, address(this), requiredBond);
+            met.safeTransferFrom(msg.sender, address(this), requiredBond);
 
             // Approve and deposit the bond into wmet
-            met.approve(address(wmet), requiredBond);
+            met.safeApprove(address(wmet), requiredBond);
             wmet.deposit(requiredBond);
         }
 
@@ -870,7 +873,7 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
         IERC20 met = wmet.metisToken();
 
         wmet.withdraw(_recipient, recipientCredit);
-        met.transfer(_recipient, recipientCredit);
+        met.safeTransfer(_recipient, recipientCredit);
     }
 
     /// @notice Returns the amount of time elapsed on the potential challenger to `_claimIndex`'s chess clock. Maxes

--- a/packages/contracts/contracts/L1/dispute/LockingPool.sol
+++ b/packages/contracts/contracts/L1/dispute/LockingPool.sol
@@ -100,6 +100,9 @@ contract LockingPool is OwnableUpgradeable, ILockingPool {
         slashRatio = _slashRatio;
         addressManager = _addressManager;
         config = _config;
+
+        emit SlashRatioUpdated(0, _slashRatio);
+        emit LockPeriodUpdated(0, _lockPeriod);
     }
 
     /// @notice Deposits tokens into the pool
@@ -129,11 +132,13 @@ contract LockingPool is OwnableUpgradeable, ILockingPool {
     /// @notice Requests to unlock tokens
     /// @param _amount Amount of tokens to unlock
     function unlock(uint256 _amount) external {
-        require(balanceOf[msg.sender] >= _amount, "LockingPool: insufficient balance");
-        
         WithdrawalRequest storage wd = withdrawals[msg.sender];
+        uint256 newAmount = wd.amount + _amount;
+
+        require(balanceOf[msg.sender] >= newAmount, "LockingPool: insufficient balance");
+
         wd.timestamp = block.timestamp;
-        wd.amount += _amount;
+        wd.amount = newAmount;
         
         emit Unlock(msg.sender, _amount);
     }

--- a/packages/contracts/contracts/L1/dispute/interfaces/IDisputeGame.sol
+++ b/packages/contracts/contracts/L1/dispute/interfaces/IDisputeGame.sol
@@ -45,8 +45,13 @@ interface IDisputeGame is IInitializable {
     /// @return l1Head_ The parent hash of the L1 block when the dispute game was created.
     function l1Head() external pure returns (Hash l1Head_);
 
-    /// @notice Getter for the extra data.
+    /// @notice Getter for the creator of the dispute game.
     /// @dev `clones-with-immutable-args` argument #4
+    /// @return creator_ The creator of the dispute game.
+    function disputeCreator() external pure returns (address creator_);
+
+    /// @notice Getter for the extra data.
+    /// @dev `clones-with-immutable-args` argument #5
     /// @return extraData_ Any extra data supplied to the dispute game contract by the creator.
     function extraData() external pure returns (bytes memory extraData_);
 

--- a/packages/contracts/contracts/L1/dispute/lib/Errors.sol
+++ b/packages/contracts/contracts/L1/dispute/lib/Errors.sol
@@ -11,6 +11,10 @@ import "./LibUDT.sol";
 /// @param gameType The unsupported game type.
     error NoImplementation(GameType gameType);
 
+/// @notice Thrown when a dispute request that already exists is attempted to be created.
+/// @param uuid The UUID of the dispute request that already exists.
+    error AlreadyDisputed(bytes32 uuid);
+
 /// @notice Thrown when a dispute game that already exists is attempted to be created.
 /// @param uuid The UUID of the dispute game that already exists.
     error GameAlreadyExists(Hash uuid);

--- a/packages/contracts/contracts/L1/dispute/wmetis/DelayedWMetis.sol
+++ b/packages/contracts/contracts/L1/dispute/wmetis/DelayedWMetis.sol
@@ -7,11 +7,14 @@ import {IDelayedWMetis} from "../interfaces/IDelayedWMetis.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /// @title DelayedWMetis
 /// @notice DelayedWMetis is a wrapper for Metis token that allows for delayed withdrawals.
 /// @dev This contract follows the same pattern as DelayedWETH but for Metis ERC20 token
 contract DelayedWMetis is OwnableUpgradeable, IDelayedWMetis, ISemver {
+    using SafeERC20 for IERC20;
+
     /// @notice Semantic version.
     /// @custom:semver 1.0.0
     string public constant version = "1.0.0";
@@ -72,7 +75,7 @@ contract DelayedWMetis is OwnableUpgradeable, IDelayedWMetis, ISemver {
 
     /// @inheritdoc IDelayedWMetis
     function deposit(uint256 _amount) external {
-        METIS.transferFrom(msg.sender, address(this), _amount);
+        METIS.safeTransferFrom(msg.sender, address(this), _amount);
         balanceOf[msg.sender] += _amount;
         emit Deposit(msg.sender, _amount);
     }
@@ -101,7 +104,7 @@ contract DelayedWMetis is OwnableUpgradeable, IDelayedWMetis, ISemver {
 
         wd.amount -= _amount;
         balanceOf[msg.sender] -= _amount;
-        METIS.transfer(msg.sender, _amount);
+        METIS.safeTransfer(msg.sender, _amount);
         emit Withdrawal(msg.sender, _amount);
     }
 
@@ -110,7 +113,7 @@ contract DelayedWMetis is OwnableUpgradeable, IDelayedWMetis, ISemver {
         require(msg.sender == owner(), "DelayedWMetis: not owner");
         uint256 balance = METIS.balanceOf(address(this));
         uint256 amount = _amount < balance ? _amount : balance;
-        METIS.transfer(msg.sender, amount);
+        METIS.safeTransfer(msg.sender, amount);
     }
 
     /// @inheritdoc IDelayedWMetis

--- a/packages/contracts/contracts/L1/rollup/IMVMStateCommitmentChain.sol
+++ b/packages/contracts/contracts/L1/rollup/IMVMStateCommitmentChain.sol
@@ -9,6 +9,14 @@ import { IChainStorageContainer } from "./IChainStorageContainer.sol";
  * @title IStateCommitmentChain
  */
 interface IMVMStateCommitmentChain {
+    /*************
+     * Types *
+     *************/
+    struct BatchInfo {
+        bytes32 batchHeaderHash;
+        uint256 lastL2BlockNumber;
+    }
+
     /**********
      * Events *
      **********/
@@ -31,9 +39,10 @@ interface IMVMStateCommitmentChain {
     /**
      * Get the earliest disputable state root.
      * @param _chainId chain id for the l2 chain.
-     * @return _earliestDisputableBatch Earliest disputable state root.
+     * @return _lastFinalized last finalized batch info.
+     * @return _earliestDisputable earliest disputable batch info.
      */
-    function findEarliestDisputableBatch(uint256 _chainId) external view returns (bytes32 _earliestDisputableBatch, uint256 blockNumber);
+    function findEarliestDisputableBatch(uint256 _chainId) external view returns (BatchInfo memory _lastFinalized, BatchInfo memory _earliestDisputable);
 
     function batches() external view returns (IChainStorageContainer);
 

--- a/packages/contracts/contracts/MVM/MVM_StateCommitmentChain.sol
+++ b/packages/contracts/contracts/MVM/MVM_StateCommitmentChain.sol
@@ -80,9 +80,18 @@ contract MVM_StateCommitmentChain is IMVMStateCommitmentChain, Lib_AddressResolv
     /**
      * @inheritdoc IMVMStateCommitmentChain
      */
-    function findEarliestDisputableBatch(uint256 _chainId) public view returns (bytes32, uint256) {
+    function findEarliestDisputableBatch(uint256 _chainId) public view returns (BatchInfo memory _lastFinalized, BatchInfo memory _earliestDisputable) {
         uint256 earliestDisputableTime = block.timestamp - FRAUD_PROOF_WINDOW;
-        return _findBatchWithinTimeWindow(_chainId, earliestDisputableTime);
+        (uint256 batchIndex, bytes32 batchHeaderHash, uint256 lastL2BlockNumberInBatch) = _findBatchWithinTimeWindow(_chainId, earliestDisputableTime);
+        _earliestDisputable = BatchInfo({
+            batchHeaderHash: batchHeaderHash,
+            lastL2BlockNumber: lastL2BlockNumberInBatch
+        });
+        bytes32 lastFinalizedBatchHeaderHash = batches().getByChainId(_chainId, batchIndex - 1);
+        _lastFinalized = BatchInfo({
+            batchHeaderHash: lastFinalizedBatchHeaderHash,
+            lastL2BlockNumber: batchLastL2BlockNumbers[lastFinalizedBatchHeaderHash]
+        });
     }
 
     /**
@@ -210,7 +219,7 @@ contract MVM_StateCommitmentChain is IMVMStateCommitmentChain, Lib_AddressResolv
         return (timestamp, sequencer, lastBlockHash, lastBlockNumber);
     }
 
-    function _findBatchWithinTimeWindow(uint256 _chainId, uint256 earliestTime) public view returns (bytes32, uint256) {
+    function _findBatchWithinTimeWindow(uint256 _chainId, uint256 earliestTime) internal view returns (uint256, bytes32, uint256) {
         bytes16[] storage batchTimesOfChain = batchTimes[_chainId];
 
         require(batchTimesOfChain.length > 0, "No disputable batch has been appended yet");
@@ -251,7 +260,7 @@ contract MVM_StateCommitmentChain is IMVMStateCommitmentChain, Lib_AddressResolv
             batchHeaderHash = batches().getByChainId(_chainId, ++batchIndex);
         }
 
-        return (batchHeaderHash, batchLastL2BlockNumbers[batchHeaderHash]);
+        return (batchIndex, batchHeaderHash, batchLastL2BlockNumbers[batchHeaderHash]);
     }
 
     /**
@@ -553,7 +562,7 @@ contract MVM_StateCommitmentChain is IMVMStateCommitmentChain, Lib_AddressResolv
         // clear the fdg extra data if needed
         if (_batchHeader.extraData.length >= 0x80) {
             (uint256 timestamp, , , ) = abi.decode(_batchHeader.extraData, (uint256, address, bytes32, uint256));
-            (bytes32 anchoredBatchHeaderHash, ) = _findBatchWithinTimeWindow(_chainId, timestamp);
+            (, bytes32 anchoredBatchHeaderHash, ) = _findBatchWithinTimeWindow(_chainId, timestamp);
 
             bytes32 batchHeaderHash = Lib_OVMCodec.hashBatchHeader(_batchHeader);
             require(

--- a/packages/data-transport-layer/src/db/simple-db.ts
+++ b/packages/data-transport-layer/src/db/simple-db.ts
@@ -75,7 +75,7 @@ export class SimpleDB {
         })
 
         stream.on('end', () => {
-          resolve(null) // 没有找到满足条件的值
+          resolve(null)
         })
       })
     } catch (err) {


### PR DESCRIPTION
- N1: added a local variable for `_a2`
- N3: removed `info.bond` check in game creation
- N4: changed to `safeERC20`
- N5: changed to `AccessControlUpgradable` for DisputeGameFactory. For other contracts,  we will use a multi-sig wallet to control permission for now.
- N7: updated unlock logic in locking pool
- N8: added event emission for `slashRatio` and `lockPeriod` in `initialize`
- N9: `findEarliestDisputableBatch` will also return the finalized batch, which will be used for the `startingOutput` in the game
- N10: added duplicate game creation check in `dispute`
- N11: the initial bound now will always return to the dispute creator (but the winner incentive will still go to the challenger)
- N12: removed repeating variables